### PR TITLE
Fix NPE on wifi connect

### DIFF
--- a/src/com/adam/aslfms/util/ScrobblesDatabase.java
+++ b/src/com/adam/aslfms/util/ScrobblesDatabase.java
@@ -304,6 +304,12 @@ public class ScrobblesDatabase {
 
 	public int queryNumberOfTracks() {
 		Cursor c;
+		if(mDb==null){
+        		this.open();
+        	}
+        	if(!mDb.isOpen()){
+        		this.open();
+        	}
 		c = mDb.rawQuery("select count(_id) from scrobbles", null);
 		int count = c.getCount();
 		if (count != 0) {


### PR DESCRIPTION
For some weird reason database is not opened and when wifi connection is established SLS crashes because mDb is null, adding this little check solves it.
